### PR TITLE
Add awesome-git-addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 ## Tools
 *Various tools for daily operations*
 
+* [awesome-git-addons](https://github.com/stevemao/awesome-git-addons) - lists more than 20 git addons including all available commands
 * [myrepos](https://myrepos.branchable.com/) - a tool to manage multiple version control repositories
 * [mu-repo](http://fabioz.github.io/mu-repo/) - a tool to help in dealing with multiple git repositories
 * [gr](http://mixu.net/gr/) - a tool for managing multiple git repositories


### PR DESCRIPTION
There is a list of awesome git addons, which also lists the available commands. The lists covers more tools than here, but also misses some tools.

Instead of replacing the existing tool list, I propose "just" to add a link to that awesome list.