### PR TITLE
Add "Flight rules for Git"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 ## Tutorial
 *There are tons of learning material on the Web*
 
-* [Flight rules for Git](https://github.com/k88hudson/git-flight-rules) - a guide about what to do when things go wrong
+* [Flight rules for Git](https://github.com/k88hudson/git-flight-rules) - guide about what to do when things go wrong
 * [Try Git](https://try.github.io/) - learn Git in 15 minutes with pseudo-terminal interface
 * [Atlassian Git Tutorial](https://www.atlassian.com/git/tutorials/) - comprehensive tutorial on Git
 * [Use gitk to understand git](https://lostechies.com/joshuaflanagan/2010/09/03/use-gitk-to-understand-git/) - all important Git terms (commit, commit SHA, branch, merge, rebase) explained using gitk

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 ## Tutorial
 *There are tons of learning material on the Web*
 
+* [Flight rules for Git](https://github.com/k88hudson/git-flight-rules) - a guide about what to do when things go wrong
 * [Try Git](https://try.github.io/) - learn Git in 15 minutes with pseudo-terminal interface
 * [Atlassian Git Tutorial](https://www.atlassian.com/git/tutorials/) - comprehensive tutorial on Git
 * [Use gitk to understand git](https://lostechies.com/joshuaflanagan/2010/09/03/use-gitk-to-understand-git/) - all important Git terms (commit, commit SHA, branch, merge, rebase) explained using gitk


### PR DESCRIPTION
This adds [Flight rules for Git](https://github.com/k88hudson/git-flight-rules). I did not want to create a new section "Howtos" and thus, I put it at "Tutorials".

The guide is so useful for users known to git. I put it in the front, because a) it should not get lost in the looooong list of Tutorials and b) newcomers will skip to the second and further list entries, because they probably will understand that this link is a not a tutorial for beginners quickly. 😇 