### PR TITLE
Add pro to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) - a set of tools for parsing [conventional commit](https://conventionalcommits.org/) messages from git histories
 * [release-it](https://github.com/webpro/release-it) - Automate releases for Git repositories and/or npm packages. Changelog generation, GitHub/GitLab releases, etc.
 * [gickup](https://github.com/cooperspencer/gickup) - Backup repos from various hosters to local or other hosters.
+* [pro](https://github.com/Wowu/pro) - A single command to quickly open current Pull Request in browser, supports GitHub and GitLab.
 
 
 ## Extensions


### PR DESCRIPTION
> `pro` - A single command to quickly open current Pull Request in browser, supports GitHub and GitLab.