### PR TITLE
Add git-plumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.
 * [tig](https://github.com/jonas/tig) - text-mode interface for git.
+* [git-plumber](https://github.com/ejiektpobehuk/git-plumber) - educational read-only git client that shows how other git clients change the content of the `.git` folder.
 
 ## Extensions
 *Git is designed for source control management. but people extend the idea and push version control to everywhere*


### PR DESCRIPTION
[git-plumber](https://github.com/ejiektpobehuk/git-plumber) is an educational read-only git client that shows how other git clients change the content of the `.git` folder.

It's usable on it's own to explore the internals of a local repository in detail.

## Category


I'm placing it in the **Tools** section because it's external to a regular git client. Even though it's not meant for "daily operations".

It's not a substitute for any other client due to its read-only nature. Thus, the use of the **Clients** section is questionable.

**Tutorials** is probably the best place for an educational piece of software, but `git-plumber` is not a tutorial.
