### PR TITLE
Add bragdoc to list of tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.
 * [tig](https://github.com/jonas/tig) - text-mode interface for git.
+* [bragdoc](https://github.com/edspencer/bragdoc-ai) - CLI that extracts achievements from git history for performance reviews.
 
 ## Extensions
 *Git is designed for source control management. but people extend the idea and push version control to everywhere*


### PR DESCRIPTION
 Adding bragdoc - a CLI tool that reads your git commits and turns them into achievement statements for performance reviews.

  Runs locally, MIT licensed.
