### PR TITLE
Add git-native-issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [git-extras](https://github.com/tj/git-extras) – git utilities adding useful git commands.
 * [git-extra-commands](https://github.com/unixorn/git-extra-commands) - Another collection of useful git commands.
 * [git-follow](https://github.com/nickolasburr/git-follow) - a tool for following lifetime changes of a file throughout the history of a Git repository.
+* [git-native-issue](https://github.com/remenoscodes/git-native-issue) - Distributed issue tracking using Git's native data model. Issues stored as commits under `refs/issues/`, synced via fetch/push.
 * [Gitrob](https://github.com/michenriksen/gitrob) - a command line tool to find sensitive information lingering in publicly available files on GitHub
 * [gitFS](https://www.presslabs.com/gitfs/) - a FUSE file system that fully integrates with git
 * [Gitless](https://gitless.com/) - an experimental version of Git that changes some of Git's underlying concepts


### PR DESCRIPTION
## Summary

[git-native-issue](https://github.com/remenoscodes/git-native-issue) — Distributed issue tracking using Git's native data model.

- Issues stored as commits under `refs/issues/`, metadata as Git trailers
- Sync via `git push/fetch` — no external database, no custom protocol
- Bridges to GitHub, GitLab, Gitea/Forgejo
- 282 tests, POSIX shell, GPL-2.0
- Includes a standalone [format specification](https://github.com/remenoscodes/git-native-issue/blob/main/ISSUE-FORMAT.md)