### PR TITLE
Add changelog-gen: AI-powered changelog generator (Claude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [GitIgnore Collection](https://github.com/github/gitignore) - collection of gitignore files for various programming language
 * [etckeeper](https://etckeeper.branchable.com/) - a collection of tools to let /etc be stored in a git repository
 * [git-extras](https://github.com/tj/git-extras) – git utilities adding useful git commands.
+- [changelog-gen](https://github.com/indoor47/changelog-gen) - AI-powered changelog generator that converts git commits into human-readable release notes using Claude
 * [git-extra-commands](https://github.com/unixorn/git-extra-commands) - Another collection of useful git commands.
 * [git-follow](https://github.com/nickolasburr/git-follow) - a tool for following lifetime changes of a file throughout the history of a Git repository.
 * [Gitrob](https://github.com/michenriksen/gitrob) - a command line tool to find sensitive information lingering in publicly available files on GitHub


### PR DESCRIPTION
Hi! I'd like to add **changelog-gen** to the list.

**[changelog-gen](https://github.com/indoor47/changelog-gen)** — AI-powered changelog generator that converts raw git commits into clean, human-readable release notes using Claude.

- Runs `git log --oneline --no-merges` on any repo
- Groups commits into Features / Bug Fixes / Performance / Refactoring / Chores
- Rewrites terse messages into plain English  
- Outputs markdown in ~5 seconds, ~$0.001 per run

```bash
python changelog_gen.py --repo . --since v1.2.0 --out CHANGELOG.md
```

Open source, MIT license. Happy to adjust the description or placement.