### PR TITLE
Add agit — AI agent reasoning preserved in git commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 *Various tools for daily operations*
 
 * [awesome-git-addons](https://github.com/stevemao/awesome-git-addons) - lists more than 20 git addons including all available commands
+* [agit](https://github.com/Madhurr/agit) - Git middleware that stores AI agent reasoning (intent, confidence, alternatives, risks, unknowns) as git notes on every commit. Works with Claude Code, Aider, Cursor, and any AI agent with a terminal.
 * [myrepos](https://myrepos.branchable.com/) - a tool to manage multiple version control repositories
 * [mu-repo](https://fabioz.github.io/mu-repo/) - a tool to help in dealing with multiple git repositories
 * [multi-gitter](https://github.com/lindell/multi-gitter) - a tool to make changes in multiple repositories simultaneously


### PR DESCRIPTION
## agit

agit is a git middleware tool that stores AI coding agent reasoning as git notes on every commit.

**Why this belongs in awesome-git:**
- Builds directly on git notes — a core git primitive (`refs/notes/*`) that few tools expose
- Pure git: no new storage format, no external database, notes travel with push/fetch
- Fills a genuine gap: there are tools for git flow, git history, git UI — but nothing for preserving agent reasoning metadata

**What it does:**

```bash
agit commit \
  -m "feat: switch auth to JWT" \
  --intent "stateless sessions, no Redis" \
  --confidence 0.82 \
  --risk "high:token-refresh:not implemented" \
  --unknowns "revocation strategy undecided"
```

`agit context show HEAD` shows intent, confidence, alternatives rejected, risks, and unknowns.
`agit diff HEAD~5..HEAD` shows how agent confidence evolved across commits.

**Repo:** https://github.com/Madhurr/agit (MIT, Go)