### PR TITLE
Add greens

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.
 * [tig](https://github.com/jonas/tig) - text-mode interface for git.
+* [greens](https://github.com/yuvrajangadsingh/greens) - mirror work contributions from a private GitHub org to your personal profile without copying source code.
 
 ## Extensions
 *Git is designed for source control management. but people extend the idea and push version control to everywhere*


### PR DESCRIPTION
Adds [greens](https://github.com/yuvrajangadsingh/greens) to the Tools section.

greens is a bash CLI that mirrors work contributions (commits, PRs, reviews, issues) from a private GitHub org to your personal profile. No source code is copied, just contribution metadata. Runs via cron.

- Homebrew installable
- Uses `gh` CLI under the hood
- Supports multi-account SSH setups