### PR TITLE
Add Factory Floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) - a simpler, faster alternative to git-filter-branch for cleansing bad data out of your Git repository history
 * [GitIgnore Collection](https://github.com/github/gitignore) - collection of gitignore files for various programming language
 * [etckeeper](https://etckeeper.branchable.com/) - a collection of tools to let /etc be stored in a git repository
+* [Factory Floor](https://github.com/alltuner/factoryfloor) - macOS workspace that automates git worktree creation, switching, and cleanup. Each worktree gets its own terminal, AI agent, and dev server.
 * [git-extras](https://github.com/tj/git-extras) – git utilities adding useful git commands.
 * [git-extra-commands](https://github.com/unixorn/git-extra-commands) - Another collection of useful git commands.
 * [git-follow](https://github.com/nickolasburr/git-follow) - a tool for following lifetime changes of a file throughout the history of a Git repository.


### PR DESCRIPTION
Adds Factory Floor to the Tools section. Factory Floor is a macOS workspace that automates git worktree lifecycle management, giving each worktree its own terminal, AI agent, and dev server.