### PR TITLE
Add gitcommitgen to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [ghq](https://github.com/motemen/ghq) — Organization for remote repositories
 * [bash-git-prompt](https://github.com/magicmonty/bash-git-prompt) - An informative and fancy bash prompt for Git users
 * [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) - a set of tools for parsing [conventional commit](https://conventionalcommits.org/) messages from git histories
+* [gitcommitgen](https://github.com/BenihDev/gitcommitgen) - AI-powered conventional commit message generator that analyzes staged changes and generates structured commit messages
 * [release-it](https://github.com/webpro/release-it) - Automate releases for Git repositories and/or npm packages. Changelog generation, GitHub/GitLab releases, etc.
 * [gickup](https://github.com/cooperspencer/gickup) - Backup repos from various hosters to local or other hosters.
 * [git-absorb](https://github.com/tummychow/git-absorb) - `git commit --fixup`, but automatic


### PR DESCRIPTION
Adding [gitcommitgen](https://github.com/BenihDev/gitcommitgen) to the Tools section. 

gitcommitgen is an AI-powered conventional commit message generator that analyzes staged changes and generates structured commit messages following the conventional commits spec. It fits naturally alongside existing entries like conventional-changelog.

- **Language:** TypeScript | **License:** MIT
- **Install:** `npm i -g @fanioz/gitcommitgen`