### PR TITLE
Add gitswitch to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.
 * [tig](https://github.com/jonas/tig) - text-mode interface for git.
+* [gitswitch](https://github.com/target-ops/gitswitch) - per-directory git identity binding with a pre-commit hook that refuses wrong-author commits
 
 ## Extensions
 *Git is designed for source control management. but people extend the idea and push version control to everywhere*


### PR DESCRIPTION
Adding [gitswitch](https://github.com/target-ops/gitswitch) under `## Tools`.

```
* [gitswitch](https://github.com/target-ops/gitswitch) - per-directory git identity binding with a pre-commit hook that refuses wrong-author commits
```

## What it does

Binds a git identity to a directory: writes an `includeIf` block to `~/.gitconfig` so every `cd` into the bound directory automatically swaps `user.email`, `user.name`, the SSH key, and the gh CLI account. Plus a pre-commit hook (`gitswitch guard`) that refuses commits when the active email doesn't match the directory's bound identity — makes "I committed as the wrong person" structurally impossible.

Single Go binary, MIT licensed, ~2 MB, no runtime dependencies. macOS arm64/x64, Linux x64/arm64, Windows. Brew install via `target-ops/homebrew-tap`.
