### PR TITLE
add hotcut to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.
 * [tig](https://github.com/jonas/tig) - text-mode interface for git.
+* [hotcut](https://github.com/zachicecreamcohn/hotcut) - orchestrates dev servers across all git worktrees simultaneously and proxies traffic to whichever is active, so no restarting when switching.
 
 ## Extensions
 *Git is designed for source control management. but people extend the idea and push version control to everywhere*


### PR DESCRIPTION
Adds [hotcut](https://github.com/zachicecreamcohn/hotcut) to the Tools section. 

Switching between git worktrees typically means killing and restarting your dev server.  hotcut eliminates that friction by running servers across all worktrees simultaneously and proxying traffic to whichever is active. 