### PR TITLE
Add CodeFever Community to Self-Hosted Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [RhodeCode CE/EE](https://rhodecode.com/) - a platform delivering enterprise source code management
 * [Soft Serve](https://github.com/charmbracelet/soft-serve) - a tasty, self-hostable Git server for the command line
 * [Harness Open Source](https://developer.harness.io/docs/open-source) - Open Source code hosting with secret scanning based on Gitleaks. Self-hosted and Apache-2.0 license.
+* [CodeFever Community](https://github.com/PGYER/codefever) - a free and open-source self-hosted Git service developed by PGYER, with one-line installation, repository management, branch protection and code review. MIT-licensed, written in PHP.
 
 ## Workflow
 *Inexpensive branching allows people adopt workflows other than the classic centralized workflow*


### PR DESCRIPTION
## What

Adds [CodeFever Community](https://github.com/PGYER/codefever) to the **Self-Hosted Repository** section, next to Gitea, Forgejo, Gogs, GitBucket, etc.

## About the project

- **License:** MIT
- **Language:** PHP (Dockerfile + docker-compose.yml available)
- **Stars:** ~2.8k on GitHub
- **Maintainer:** [PGYER](https://github.com/PGYER), a developer-tools company operating since 2014 (12+ years), best known as China's leading mobile-app beta-distribution platform
- **Status:** Fully open-source self-hosted Git platform with one-line install, repository management, branch protection, code review, and team collaboration

CodeFever fits the section's theme well — it's a true self-hosted Git repository server in the same category as Gitea/Forgejo/Gogs, and gives readers an additional vendor-official open-source option from outside the existing ecosystem.

Thanks for maintaining this list!