### PR TITLE
Add GitSquid (Git GUI client) to Client section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [Vershd](https://vershd.io/) - a free for personal use effortless Git GUI for Windows, Mac, & Linux.
 * [lazygit](https://github.com/jesseduffield/lazygit) - A simple terminal UI for git commands, written in Go
 * [Gittyup](https://github.com/Murmele/Gittyup) - a graphical Git client designed to help you understand and manage your source code history.
+* [GitSquid](https://gitsquid.dev) - a cross-platform Git GUI client built with Tauri and Rust. native macOS, Windows and Linux. free tier and Pro version available.
 
 
 ## Repository Hosting

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [Vershd](https://vershd.io/) - a free for personal use effortless Git GUI for Windows, Mac, & Linux.
 * [lazygit](https://github.com/jesseduffield/lazygit) - A simple terminal UI for git commands, written in Go
 * [Gittyup](https://github.com/Murmele/Gittyup) - a graphical Git client designed to help you understand and manage your source code history.
-* [GitSquid](https://gitsquid.dev) - a cross-platform Git GUI client built with Tauri and Rust. native macOS, Windows and Linux. no account, no telemetry.
+* [GitSquid](https://gitsquid.dev) - a cross-platform Git GUI client built with Tauri and Rust. native macOS, Windows and Linux. free tier and Pro version available.
 
 
 ## Repository Hosting

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [Vershd](https://vershd.io/) - a free for personal use effortless Git GUI for Windows, Mac, & Linux.
 * [lazygit](https://github.com/jesseduffield/lazygit) - A simple terminal UI for git commands, written in Go
 * [Gittyup](https://github.com/Murmele/Gittyup) - a graphical Git client designed to help you understand and manage your source code history.
-* [GitSquid](https://gitsquid.dev) - a cross-platform Git GUI client built with Tauri and Rust. native macOS, Windows and Linux. free tier and Pro version available.
+* [GitSquid](https://gitsquid.dev) - a cross-platform Git GUI client built with Tauri and Rust. native macOS, Windows and Linux. no account, no telemetry.
 
 
 ## Repository Hosting


### PR DESCRIPTION
Adds GitSquid, a cross-platform Git GUI client (macOS / Windows / Linux), to the **Client** section.

Built with Tauri + Rust — native binaries on all three platforms (arm64 + x64). Free tier covers most workflows; Pro version available. No account required, no telemetry.

Entry placed at the end of the section, consistent with the existing chronological order of entries.