### PR TITLE
Add gitprofile

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.
 * [tig](https://github.com/jonas/tig) - text-mode interface for git.
+* [gitprofile](https://github.com/meanii/gitprofile) - manage multiple git identities (work, personal, open-source) using git's includeIf directive, so the right name, email and SSH key are picked up automatically.
 
 ## Extensions
 *Git is designed for source control management. but people extend the idea and push version control to everywhere*


### PR DESCRIPTION
gitprofile lets you manage multiple git identities without touching
~/.ssh/config or setting up per-repo config manually. It writes
includeIf blocks to ~/.gitconfig so git picks the right identity
for any repo under a given directory.

https://github.com/meanii/gitprofile