### PR TITLE
Add gity to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.
 * [tig](https://github.com/jonas/tig) - text-mode interface for git.
+* [gity](https://github.com/neul-labs/gity) - A cross-platform Rust daemon that accelerates Git on large repos via the fsmonitor protocol.
 
 ## Extensions
 *Git is designed for source control management. but people extend the idea and push version control to everywhere*


### PR DESCRIPTION
Hi! Adding gity to `## Tools`.

[gity](https://github.com/neul-labs/gity) is a cross-platform Rust daemon that accelerates Git on large repositories. It implements the Git `fsmonitor` v2 protocol, watches the working tree with native OS file watchers (inotify / FSEvents / ReadDirectoryChangesW), runs `git maintenance` during idle, and caches status results — so `git status` in a million-file repo returns in milliseconds.

- License: MIT
- Cross-platform: Linux, macOS, Windows
- Distributed via crates.io, npm (`gity-cli`), PyPI, Homebrew, and platform-native packages
- I am a maintainer of the project.