### PR TITLE
Add grite

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.
 * [tig](https://github.com/jonas/tig) - text-mode interface for git.
+* [grite](https://github.com/neul-labs/grite) - git-backed issue tracker for AI coding agents. Issues live as an event log in `refs/grite/wal`, sync via `git push`/`fetch`, and merge conflict-free via CRDTs.
 
 ## Extensions
 *Git is designed for source control management. but people extend the idea and push version control to everywhere*


### PR DESCRIPTION
Adds grite (https://github.com/neul-labs/grite) — a git-backed, repo-local issue tracker with CRDT-based conflict-free merging, designed for AI coding agents. Issues are stored as an append-only event log in `refs/grite/wal` and sync via `git push`/`fetch`, requiring no server or database. Stable `--json` output and a `grite install-skill` command make it scriptable from agents like Claude Code. MIT licensed.

Placed under **Tools** since grite is a CLI built around git refs and uses push/fetch as its sync primitive.