### PR TITLE
Add gitj as a new Git GUI client option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [GitHub Desktop](https://desktop.github.com/) - Git Client by GitHub. works with GitHub and GitHub Enterprise seamlessly
 * [SourceTree](https://www.sourcetreeapp.com/) - free (in-beer) GUI client. Windows and Mac only
 * [Tower](https://www.git-tower.com/) - a popular non-free Git GUI client. Mac and Windows
-* [gitj (Git Journey)](https://github.com/roblillack/gitj) - Fast, small, cross-platform GUI git client (gitk/git-gui style) with image diff support
 * [GitKraken](https://www.gitkraken.com/) - a cross Git client for Windows, Mac & Linux. Electron based. Free for non-commercial use and paid Pro version is available.
 * [Fork](https://git-fork.com) - An awesome and free git client for macOS and Windows
 * [TortoiseGit](https://tortoisegit.org/) - an easy-to-use Git client on Windows. well-integrated with Windows Explorer.
@@ -86,7 +85,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [Vershd](https://vershd.io/) - a free for personal use effortless Git GUI for Windows, Mac, & Linux.
 * [lazygit](https://github.com/jesseduffield/lazygit) - A simple terminal UI for git commands, written in Go
 * [Gittyup](https://github.com/Murmele/Gittyup) - a graphical Git client designed to help you understand and manage your source code history.
-
+* [gitj (Git Journey)](https://github.com/roblillack/gitj) - Fast, small, cross-platform GUI git client (gitk/git-gui style) with image diff support
 
 ## Repository Hosting
 *People have plenty of options to host their source code*

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [GitHub Desktop](https://desktop.github.com/) - Git Client by GitHub. works with GitHub and GitHub Enterprise seamlessly
 * [SourceTree](https://www.sourcetreeapp.com/) - free (in-beer) GUI client. Windows and Mac only
 * [Tower](https://www.git-tower.com/) - a popular non-free Git GUI client. Mac and Windows
+* [gitj (Git Journey)](https://github.com/roblillack/gitj) - Fast, small, cross-platform GUI git client (gitk/git-gui style) with image diff support
 * [GitKraken](https://www.gitkraken.com/) - a cross Git client for Windows, Mac & Linux. Electron based. Free for non-commercial use and paid Pro version is available.
 * [Fork](https://git-fork.com) - An awesome and free git client for macOS and Windows
 * [TortoiseGit](https://tortoisegit.org/) - an easy-to-use Git client on Windows. well-integrated with Windows Explorer.


### PR DESCRIPTION
Hey there, :wave: 

I'd like to propose adding [gitj](https://github.com/roblillack/gitj) to the list of GUI clients. It's a small & fast cross-platform alternative to `gitk` and `git-gui` in one tool. It features three modes: "browse" to view the history of the current branch, "commit" to stage/unstage individual files or even lines and compare to the committed state, and "review" to review changes on a branch level.

<img width="1376" height="1016" alt="image" src="https://github.com/user-attachments/assets/3b882f65-cca7-4792-97c1-7fd798c527ff" />
