### PR TITLE
Add Git & GitHub Cheatsheet to Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [Git & Git-Flow Cheat Sheet](https://github.com/arslanbilal/git-cheat-sheet)
 * [Git Tips](https://github.com/git-tips/tips)
 * [Interactive/Contextual/Visual Cheat Sheet](https://ndpsoftware.com/git-cheatsheet.html)
+* [Git & GitHub Cheatsheet](https://gitcheatsheets.org/) - fast, searchable reference of essential Git and GitHub commands, with copy-to-clipboard and light/dark themes
 * [The 'Git Pretty' Flow-Chart](http://justinhileman.info/article/git-pretty/git-pretty.png) - How to Recover from a Mess
 * [Software Carpentry: Git Lessons](https://software-carpentry.org/lessons/)
 * [The Git Parable](http://tom.preston-werner.com/2009/05/19/the-git-parable.html) - GitHub Cofounder's Narrative-style Intro to Git Concepts


### PR DESCRIPTION
Adds [Git & GitHub Cheatsheet](https://gitcheatsheets.org/) to the **Tutorial** section, alongside the existing cheat sheets.

It's a fast, searchable quick-reference of every essential Git and GitHub command, with copy-to-clipboard on each command and light/dark themes. Free, no ads or tracking.

Disclosure: I'm the author — glad to adjust wording or placement to fit the list's style.