### PR TITLE
Add PR Radar to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.
 * [tig](https://github.com/jonas/tig) - text-mode interface for git.
+* [PR Radar](https://github.com/deployhq/pr-radar) - a browser extension giving a unified pull request dashboard across GitHub, GitLab, and Bitbucket: CI status, unresolved comments, review state, and notifications without keeping a tab open.
 
 ## Extensions
 *Git is designed for source control management. but people extend the idea and push version control to everywhere*


### PR DESCRIPTION
Adds **PR Radar** to the *Tools* section.

PR Radar is a browser extension giving a unified pull request dashboard across **GitHub, GitLab, and Bitbucket** — CI status, unresolved comments, review state, and notifications, without keeping a tab open. Like the cross-hoster tools already listed (e.g. gitbackup, soba), it works across all three major Git hosts.

- Source: https://github.com/deployhq/pr-radar
- Chrome Web Store: https://chromewebstore.google.com/detail/hkombgibegjffiadmekpiabdakkoidmh