### PR TITLE
Add sem to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.
 * [tig](https://github.com/jonas/tig) - text-mode interface for git.
+* [sem](https://github.com/Ataraxy-Labs/sem) - semantic git: diff, blame, and impact analysis at the function/class level (not lines) across 32 languages via tree-sitter.
 
 ## Extensions
 *Git is designed for source control management. but people extend the idea and push version control to everywhere*


### PR DESCRIPTION
Adds [sem](https://github.com/Ataraxy-Labs/sem) under Tools.

sem extends git with entity-level operations: it diffs, blames, and runs impact analysis at the function/class/method level instead of by lines, across 32 languages via tree-sitter. Useful for reviewing what actually changed structurally and what a change might affect.