### PR TITLE
Add Alpheon to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [release-it](https://github.com/webpro/release-it) - Automate releases for Git repositories and/or npm packages. Changelog generation, GitHub/GitLab releases, etc.
 * [gickup](https://github.com/cooperspencer/gickup) - Backup repos from various hosters to local or other hosters.
 * [git-absorb](https://github.com/tummychow/git-absorb) - `git commit --fixup`, but automatic
+* [Alpheon](https://github.com/BravoAlphaSix/alpheon) - reads your diff and drafts a reviewable handoff note (what changed, why, what was tried and rejected, what's next) into a `HANDOFF.md` in your repo
 * [jc --git-log](https://kellyjonbrazil.github.io/jc/docs/parsers/git_log) - Convert your git log to JSON.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.


### PR DESCRIPTION
Adds Alpheon, a small dependency-free CLI that reads your git diff and drafts a reviewable handoff note (what changed, why, what was tried and rejected, what's next) saved as HANDOFF.md in your repo. MIT licensed.