### PR TITLE
Add Git Handoff Checker to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.
 * [tig](https://github.com/jonas/tig) - text-mode interface for git.
+* [Git Handoff Checker](https://github.com/zhailong8845-art/git-handoff-checker) - Fail-closed pre-delivery checks for clean worktrees, upstream state, and pushed commits.
 
 ## Extensions
 *Git is designed for source control management. but people extend the idea and push version control to everywhere*


### PR DESCRIPTION
## Summary

Adds Git Handoff Checker to the Tools section. It is an MIT-licensed, dependency-free utility that checks whether a Git repository is safe to hand off: clean worktree, named branch, configured upstream, ahead/behind state, and pushed commits.

## Validation

- Confirmed the repository link returns HTTP 200.
- Confirmed the entry appears exactly once.
- Ran `git diff --check` successfully.
- The tool repository includes five passing automated tests and a versioned release.

Related project: https://github.com/zhailong8845-art/git-handoff-checker