### PR TITLE
Add stepback to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [gitbackup](https://github.com/amitsaha/gitbackup) - a tool to backup your Bitbucket, GitHub and GitLab repositories.
 * [soba](https://github.com/jonhadfield/soba) - scheduled backups of repositories from popular providers with change detection.
 * [tig](https://github.com/jonas/tig) - text-mode interface for git.
+* [stepback](https://github.com/Archerkattri/stepback) - checkpoint and rewind for AI coding agent sessions using isolated git shadow-refs (refs/checkpoints/), so an agent's edits can be undone exactly without ever touching HEAD, the index, or branch history.
 
 ## Extensions
 *Git is designed for source control management. but people extend the idea and push version control to everywhere*


### PR DESCRIPTION
## Summary

Adds [stepback](https://github.com/Archerkattri/stepback) to the Tools section. Disclosure: it's my own project.

stepback is a checkpoint/rewind CLI built entirely on git plumbing (`hash-object`, `write-tree`, `commit-tree`, `update-ref`) with a private index. It snapshots a working tree into an isolated `refs/checkpoints/` namespace and restores exactly on rewind — binary files, symlinks, unicode/space/leading-dash names, deletions all handled — while never calling `update-ref` on HEAD or any branch, never committing onto a branch, and never touching the real index. Outside a git repo it falls back to a private shadow object store (`.stepback/shadow.git`) using the same plumbing. Originally built for wrapping AI coding agents (it optionally also snapshots Claude Code / Codex session transcripts), but the file-checkpoint layer itself is agent-agnostic — just git.

## Links

- Repo: https://github.com/Archerkattri/stepback
- PyPI: https://pypi.org/project/stepback/