### PR TITLE
Add relnote to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [bash-git-prompt](https://github.com/magicmonty/bash-git-prompt) - An informative and fancy bash prompt for Git users
 * [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) - a set of tools for parsing [conventional commit](https://conventionalcommits.org/) messages from git histories
 * [release-it](https://github.com/webpro/release-it) - Automate releases for Git repositories and/or npm packages. Changelog generation, GitHub/GitLab releases, etc.
+* [relnote](https://github.com/loki-inu/relnote) - Offline stdlib Python CLI and GitHub Action for conventional-commit release notes (no API, no config).
 * [gickup](https://github.com/cooperspencer/gickup) - Backup repos from various hosters to local or other hosters.
 * [git-absorb](https://github.com/tummychow/git-absorb) - `git commit --fixup`, but automatic
 * [jc --git-log](https://kellyjonbrazil.github.io/jc/docs/parsers/git_log) - Convert your git log to JSON.


### PR DESCRIPTION
## Why
Adds [relnote](https://github.com/loki-inu/relnote) under Tools, next to `conventional-changelog` and `release-it`.

relnote is a small offline CLI (stdlib Python) plus a reusable GitHub Action that turns conventional commits into a GitHub Release body. No GitHub API, no config file.

## Links
- Repo: https://github.com/loki-inu/relnote
- Docs: https://loki-inu.github.io/relnote/