### PR TITLE
Add PR Cockpit

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Pull requests on interesting tools/projects/resources are welcome.
 * [lazygit](https://github.com/jesseduffield/lazygit) - A simple terminal UI for git commands, written in Go
 * [Gittyup](https://github.com/Murmele/Gittyup) - a graphical Git client designed to help you understand and manage your source code history.
 * [gitj (Git Journey)](https://github.com/roblillack/gitj) - Fast, small, cross-platform GUI git client (gitk/git-gui style) with image diff support
+* [PR Cockpit](https://prcockpit.com/) - an extremely fast GitHub for reviewing pull requests: PRs open in about 20 ms. Keyboard-first, with a CLI for coding agents.
 
 ## Repository Hosting
 *People have plenty of options to host their source code*


### PR DESCRIPTION
PR Cockpit is an extremely fast GitHub for reviewing pull requests on macOS and Linux: a PR opens in about 20 ms, against 1.4 s for github.com on the same repository (p50, [docs/BENCHMARKS.md](https://github.com/theolundqvist/pr-cockpit/blob/main/docs/BENCHMARKS.md)).

I put it in the Client section because that is where the GitHub-facing GUI clients live, next to GitHub Desktop and Gittyup; happy to move it to Tools or a new subsection if you prefer.

Repo: https://github.com/theolundqvist/pr-cockpit (MIT) — Site: https://prcockpit.com
